### PR TITLE
Add version tag for jQuery 3.5+ compatibility

### DIFF
--- a/dashboards/extended_search_reporting.xml
+++ b/dashboards/extended_search_reporting.xml
@@ -1,4 +1,4 @@
-<form>
+<form version="1.1">
   <label>Extended Search Reporting, v1.6</label>
   <!-- Author: David Paper, dpaper@splunk.com -->
   <fieldset submitButton="false"></fieldset>

--- a/dashboards/metrics_related_to_ingestion_blockage.xml
+++ b/dashboards/metrics_related_to_ingestion_blockage.xml
@@ -1,4 +1,4 @@
-<form>
+<form version="1.1">
   <label>Metrics Related to Ingestion Blockage, v1.3</label>
   <fieldset submitButton="false">
     <input type="time" token="field1">

--- a/dashboards/stack_health-cloud.xml
+++ b/dashboards/stack_health-cloud.xml
@@ -1,4 +1,4 @@
-<dashboard>
+<dashboard version="1.1">
   <!-- Cloud -->
   <label>Stack Health of Data Onboarding, v1.7.0 beta (cloud)</label>
   <search>

--- a/dashboards/stack_health-onprem.xml
+++ b/dashboards/stack_health-onprem.xml
@@ -1,4 +1,4 @@
-<dashboard>
+<dashboard version="1.1">
 <!-- On Prem -->
   <label>Stack Health of Data Onboarding, v1.3 (on prem)</label>
   <search>


### PR DESCRIPTION
Splunk 8.2+ requires dashboards to include version tags for jQuery 3.5 compatibility. This PR adds those tags.