### PR TITLE
Update extended_search_reporting.xml

### DIFF
--- a/dashboards/extended_search_reporting.xml
+++ b/dashboards/extended_search_reporting.xml
@@ -1,14 +1,20 @@
 <form version="1.1">
-  <label>Extended Search Reporting, v1.7</label>
-
+  <label>Extended Search Reporting, v1.6.1</label>
+  <description>to test edits</description>
   <!-- Author: David Paper, dpaper@splunk.com -->
-  <fieldset submitButton="false"></fieldset>
+  <fieldset submitButton="true" autoRun="false">
+    <input type="text" token="App" searchWhenChanged="false">
+      <label>App</label>
+      <default>*</default>
+    </input>
+  </fieldset>
   <row>
     <panel>
-      <html>
-      The Extended Search Reporting dashboard is here to augment your Splunk management efforts with information and views not available in the Monitoring Console. It is meant to run on a standalone Search Head or Search Head Cluster. Access to REST and the _* indexes are necessary for this view to render properly. Latest version can be found at <a href="https://github.com/dpaper-splunk/public">https://github.com/dpaper-splunk/public</a>.
+      <html> 
+      The Extended Search Reporting dashboard is here to augment your Splunk management efforts with information and views not available in the Monitoring Console. It is meant to run on a stand alone Search Head or Search Head Cluster. Access to REST and the _* indexes are necessary for this view to render properly. Latest version can be found at <a href="https://github.com/dpaper-splunk/public">https://github.com/dpaper-splunk/public</a>.
       <p/>
-      Feedback is welcome via github or directly to David Paper at dpaper@splunk.com or @cerby on Splunk usergroups Slack.
+      Feedback is welcomes via github or directly to David Paper at dpaper@splunk.com or @cerby on Splunk usergroups Slack.
+      
       </html>
     </panel>
   </row>
@@ -17,13 +23,12 @@
       <html>
   <h3>Search Efficiency Ratings</h3>
   <p/>
-  Description: The efficiency panel is a ranking of searches based on how efficient the searches are. The value represents a function of how often the search runs and how long it takes to run. A search running often, and that takes a long time, will have a low efficiency value. Searches that run in less time raise the efficiency value.
+  Description: The efficiency panel is a ranking of searches based on how efficient the searches are. The value represents a function of how often the search runs and how long it takes to run. A search running often and takes a long time will have a low efficiency value. Searches that run in less time raise efficiency value.
   <p/>
   Higher efficiency values, relative to each other, are better. Anything below 10 should be considered for improvement in SPL, time range, or change in frequency of scheduling.
   <p/>
   Actions to take: Review how often the search is scheduled to run, and if it is a frequently scheduled search, optimize SPL to complete quicker. Assistance can be found on <a href="http://docs.splunk.com/Documentation/Splunk/latest/Search/Writebettersearches">http://docs.splunk.com/Documentation/Splunk/latest/Search/Writebettersearches</a>.
   <p/>
-  Time frame: Trending over the past 60 minutes.
 </html>
     </panel>
   </row>
@@ -41,22 +46,30 @@
         <suffix>)</suffix>
         <delimiter> AND </delimiter>
       </input>
+      <input type="time" token="efficiency_time" searchWhenChanged="true">
+        <label></label>
+        <default>
+          <earliest>-7d@h</earliest>
+          <latest>now</latest>
+        </default>
+      </input>
       <table>
         <search id="efficiency">
-          <query>index=_internal sourcetype=scheduler source=*scheduler.log (status=success OR status=completed) $Exclusions$
-| stats avg(run_time) as average_runtime_in_sec count(savedsearch_name) as weekly_count sum(run_time) as total_runtime_sec by savedsearch_name user app host
-| eval Ran_every_x_Minutes=60/(weekly_count/168)
-| eval average_runtime_in_minutes=average_runtime_in_sec/60
-| eval efficiency=((60/(weekly_count/168))/(average_runtime_in_sec/60))
-| sort efficiency |eval average_runtime_in_sec=round(average_runtime_in_sec,2), Ran_every_x_Minutes=round(Ran_every_x_Minutes,2), efficiency=round(efficiency,2), average_runtime_in_minutes=round(average_runtime_in_minutes,2)
-| rename savedsearch_name AS "Saved Search Name", user AS "User", efficiency AS "Efficiency", app AS "App", host AS "Host", average_runtime_in_sec AS "Avg Runtime Secs", weekly_count AS "Weekly Count", total_runtime_sec AS "Total Runtime Secs", Ran_every_x_Minutes AS "Ran Every X Mins", average_runtime_in_minutes AS "Avg Runtime In Mins"
-| table "Saved Search Name","User", "Efficiency", "App", "Host", "Avg Runtime Secs", "Weekly Count", "Total Runtime Secs", "Ran Every X Mins", "Avg Runtime In Mins"</query>
-          <earliest>-60m@m</earliest>
-          <latest>now</latest>
-          <sampleRatio>1</sampleRatio>
           <progress>
             <eval token="efficiency_duration">tostring(round(tonumber($job.runDuration$),2),"duration")</eval>
           </progress>
+          <query>index=_internal sourcetype=scheduler source=*scheduler.log (status=success OR status=completed) $Exclusions$ app=$App$
+| stats avg(run_time) as average_runtime_in_sec count(savedsearch_name) as weekly_count sum(run_time) as total_runtime_sec by savedsearch_name user app host
+| eval Ran_every_x_Minutes=round(60/(weekly_count/168),2)
+| eval average_runtime_in_minutes=round(average_runtime_in_sec/60,2)
+| eval efficiency=round(((60/(weekly_count/168))/(average_runtime_in_sec/60)),2)
+|eval average_runtime_in_sec=round(average_runtime_in_sec,2)
+| sort efficiency 
+| rename savedsearch_name AS "Saved Search Name", user AS "User", efficiency AS "Efficiency", app AS "App", host AS "Host", average_runtime_in_sec AS "Avg Runtime Secs", weekly_count AS "Weekly Count", total_runtime_sec AS "Total Runtime Secs", Ran_every_x_Minutes AS "Ran Every X Mins", average_runtime_in_minutes AS "Avg Runtime In Mins"
+| table "Saved Search Name" "User"  "Efficiency" "Ran Every X Mins" "Avg Runtime In Mins" "Avg Runtime Secs" "Total Runtime Secs" "Weekly Count" "App" "Host"</query>
+          <earliest>$efficiency_time.earliest$</earliest>
+          <latest>$efficiency_time.latest$</latest>
+          <sampleRatio>1</sampleRatio>
         </search>
         <option name="count">10</option>
         <option name="dataOverlayMode">none</option>
@@ -66,6 +79,9 @@
         <option name="rowNumbers">false</option>
         <option name="totalsRow">false</option>
         <option name="wrap">true</option>
+        <format type="number" field="Ran Every X Mins"></format>
+        <format type="number" field="Total Runtime Secs"></format>
+        <format type="number" field="Avg Runtime Secs"></format>
       </table>
       <html>
           <h3>Panel Execution Duration</h3>
@@ -78,13 +94,12 @@
       <html>
   <h3>Events Scanned vs Returned</h3>
   <p/>
-  Description: This view provides insight into which searches have a very low count of results returned versus count of results read from disk. This is expressed as a ratio called lispy_efficiency. The closer to 1.0 the lispy_efficiency ratio is, the better the search is. A low ratio indicates Splunk is reading a large number of events but ultimately returning very few to the user.
+  Description: This view provides insight into which searches have a very low count of results returned versus count of results scanned. This is expressed as a  ratio called lispy_efficiency. The closer to 1.0 the lispy_efficiency ratio is, the better the search is. A low ratio indicates Splunk is reading a large number of events but ultimately returning very few to the user.
   <p/>
   If savedsearch_name is blank, its an adhoc search.
   <p/>
   Actions to take: Review the values before the first | to include as many specific search terms as possible. Pay attention to searches using wildcards, small numbers, and filtering with NOT - especially for fields. Assistance can be found on <a href="http://docs.splunk.com/Documentation/Splunk/latest/Search/Writebettersearches">http://docs.splunk.com/Documentation/Splunk/latest/Search/Writebettersearches</a> and a deep dive on this topic on <a href="https://conf.splunk.com/files/2017/slides/fields-indexed-tokens-and-you.pdf">https://conf.splunk.com/files/2017/slides/fields-indexed-tokens-and-you.pdf</a>.
   <p/>
-  Time frame: Trending over the past 60 minutes.
 </html>
     </panel>
   </row>
@@ -96,22 +111,34 @@
         <choice value="savedsearch_name _time">No</choice>
         <choice value="savedsearch_name search _time">Yes</choice>
         <default>savedsearch_name _time</default>
+        <!--
+        <change>
+          <set token="include_search_string">$label$</set>
+        </change>
+        -->
+      </input>
+      <input type="time" token="scanned_v_returned_time" searchWhenChanged="false">
+        <label></label>
+        <default>
+          <earliest>-60m@m</earliest>
+          <latest>now</latest>
+        </default>
       </input>
       <table>
         <search id="events_scanned_vs_returned">
-          <query>index=_audit search_id TERM(action=search) (info=granted OR info=completed) 
+          <progress>
+            <eval token="lispyefficiency_duration">tostring(round(tonumber($job.runDuration$),2),"duration")</eval>
+          </progress>
+          <query>index=_audit search_id TERM(action=search) (info=granted OR info=completed) app=$App$
 | stats first(_time) as _time first(total_run_time) as total_run_time first(event_count) as event_count first(scan_count) as
    scan_count first(user) as user first(savedsearch_name) as savedsearch_name first(search) as search by search_id 
 | eval lispy_efficiency = round((event_count / scan_count),5)
 | where lispy_efficiency &lt; 0.5 AND total_run_time &gt; 5 AND scan_count &gt; 100
 | sort - total_run_time 
 | table total_run_time event_count scan_count lispy_efficiency user $include_search_string$ search_id</query>
-          <earliest>-60m@m</earliest>
-          <latest>now</latest>
+          <earliest>$scanned_v_returned_time.earliest$</earliest>
+          <latest>$scanned_v_returned_time.latest$</latest>
           <sampleRatio>1</sampleRatio>
-          <progress>
-            <eval token="lispyefficiency_duration">tostring(round(tonumber($job.runDuration$),2),"duration")</eval>
-          </progress>
         </search>
         <option name="count">10</option>
         <option name="dataOverlayMode">none</option>
@@ -123,7 +150,7 @@
         <option name="wrap">true</option>
       </table>
       <html>
-          <h3>Panel Execution Duration</h3>
+          <h3>Panel Execution  Duration</h3>
           <div class="custom-result-value">$lispyefficiency_duration$</div>
       </html>
     </panel>
@@ -131,21 +158,20 @@
   <row>
     <panel>
       <html>
-  <h3>Frequency and Span Comparison</h3>
+  <h3>Frequency and Search Span Comparison</h3>
   <p/>
-  Description: Often a search is scheduled to run frequently with a very long span between earliest and latest. While it makes sense for a search run every 5 minutes to look back 10 minutes (-11m@m to -1m@m, delayed a minute to allow straggler events to be indexed and caught by the search), it probably doesn't make sense for a search running every 5 minutes to look back 4 or 24 hours. Likewise, a search that run once an hour probably doesn't need to look back at the last 24 hours or 7 days. These searches end up being resource hogs due to the frequency they run. Any search with a ratio higher than 20:1 (default) of frequency to duration is shown. Use the dropdown to alter the ratio to display.
+  Description: Often a search is scheduled to run frequently with a very long search window. While it makes sense for a search run every 5 minutes to look back 10 minutes (-11m@m to -1m@m, delayed a minute to allow straggler events to be indexed and caught by the search), it probably doesn't make sense for a search running every 5 minutes to look back 4 or 24 hours. Likewise, a search that run once an hour probably doesn't need to look back at the last 24 hours or 7 days. These searches end up being resource hogs due to the frequency they run. Any search with a ratio higher than 20:1 (default) of frequency to span is shown. Use the dropdown to alter the ratio to display.
   <p/>
   There is no right answer for what an acceptable ratio is - some searches may need a longer look back than others. The closer to 1:1 the better. A search that runs every minute shouldn't need to look back more than 2 or 3 minutes. Note that there are some edge case cron schedules that don't get parsed correctly.
   <p/>
-  Actions to take: Review how often the search is scheduled to run and the duration it's running against. Does it make sense? Ensure that searches with high ratios that need to maintain the ratio are as efficient as possible. Assistance can be found on <a href="http://docs.splunk.com/Documentation/Splunk/latest/Search/Writebettersearches">http://docs.splunk.com/Documentation/Splunk/latest/Search/Writebettersearches</a>.
+  Actions to take: Review how often the search is scheduled to run and the span it's running across. Does it make sense? Ensure that searches with high ratios that need to maintain the ratio are as efficient as possible. Assistance can be found on <a href="http://docs.splunk.com/Documentation/Splunk/latest/Search/Writebettersearches">http://docs.splunk.com/Documentation/Splunk/latest/Search/Writebettersearches</a>.
   <p/>
-  Time frame: Trending over the past 4 hours.
 </html>
     </panel>
   </row>
   <row>
     <panel>
-      <title>Frequency and Span Comparison</title>
+      <title>Frequency and Search Span Comparison</title>
       <input type="dropdown" token="ratio" searchWhenChanged="true">
         <label>Select ratio threshold</label>
         <choice value="3">3:1</choice>
@@ -155,9 +181,19 @@
         <choice value="50">50:1</choice>
         <default>20</default>
       </input>
+      <input type="time" token="frequency_span_time" searchWhenChanged="true">
+        <label></label>
+        <default>
+          <earliest>-24h@h</earliest>
+          <latest>now</latest>
+        </default>
+      </input>
       <table>
         <search id="frequency_vs_span_ratio">
-          <query>index=_audit sourcetype=audittrail source=audittrail savedsearch_name!="" TERM(action=search) ( TERM(info=completed) OR ( TERM(info=granted) search_et=* "search='search")) NOT "search_id='rsa_*" 
+          <progress>
+            <eval token="freqvsdur_duration">tostring(round(tonumber($job.runDuration$),2),"duration")</eval>
+          </progress>
+          <query>index=_audit sourcetype=audittrail source=audittrail savedsearch_name!="" TERM(action=search) ( TERM(info=completed) OR ( TERM(info=granted) search_et=* "search='search")) NOT "search_id='rsa_*"  app=$App$
 | eval timesearched = round((search_lt-search_et),0)
 | fields savedsearch_name, timesearched, user
 | join savedsearch_name 
@@ -185,19 +221,15 @@
 | eval ratio=round(timesearched/cron_minimum_freq,0) . ":" . 1, timesearched=round(timesearched/60,0), cron_minimum_freq=cron_minimum_freq/60
 | dedup savedsearch_name 
 | table savedsearch_name, eai:acl.app, user, timesearched, cron_minimum_freq, cron_schedule, ratio 
-| rename savedsearch_name AS "Saved Search Name", eai:acl.app AS "App", user AS "User", timesearched AS "Time Searched (Minutes)", cron_minimum_freq as "Minimum Frequency (Minutes)", cron_schedule AS "Cron Schedule", ratio as Ratio</query>
-          <earliest>-4h@m</earliest>
-          <latest>now</latest>
+| rename savedsearch_name AS "Saved Search Name", eai:acl.app AS "App", user AS "User", timesearched AS "Search Span (Minutes)", cron_minimum_freq as "Minimum Frequency (Minutes)", cron_schedule AS "Cron Schedule", ratio as Ratio</query>
+          <earliest>$frequency_span_time.earliest$</earliest>
+          <latest>$frequency_span_time.latest$</latest>
           <sampleRatio>1</sampleRatio>
-          <progress>
-            <eval token="freqvsdur_duration">tostring(round(tonumber($job.runDuration$),2),"duration")</eval>
-          </progress>
         </search>
-        <option name="count">100</option>
+        <option name="count">10</option>
         <option name="dataOverlayMode">none</option>
         <option name="drilldown">none</option>
         <option name="percentagesRow">false</option>
-        <option name="refresh.display">progressbar</option>
         <option name="rowNumbers">false</option>
         <option name="totalsRow">false</option>
         <option name="wrap">true</option>
@@ -211,43 +243,121 @@
   <row>
     <panel>
       <html>
+  <h3>Search Frequency vs Maximum Run Time Comparison</h3>
+  <p/>
+  Description: The frequency vs run time panel is comparing how frequenly a search runs to how the maximum time it took for the search to run.  When a search takes longer to run than the exection frequency, it can cause concurrency or skipping problems. 
+    <p/>
+  This panel identifies both searches where run time already exceeds frequency and those where run time is withn 20% of frequency 
+  <p/>
+  Actions to take: Review each search to optimize SPL to complete within the scheduled frequency or adjust the cron schedule to account for search run time. Assistance can be found on <a href="http://docs.splunk.com/Documentation/Splunk/latest/Search/Writebettersearches">http://docs.splunk.com/Documentation/Splunk/latest/Search/Writebettersearches</a>.
+  <p/>
+</html>
+    </panel>
+  </row>
+  <row>
+    <panel>
+      <title>Frequency vs Run Time Comparison</title>
+      <input type="time" token="freq_v_runtime_time" searchWhenChanged="true">
+        <label></label>
+        <default>
+          <earliest>-7d@h</earliest>
+          <latest>now</latest>
+        </default>
+      </input>
+      <table>
+        <search id="freq_v_runtime">
+          <progress>
+            <eval token="lispyfreq_v_runtime">tostring(round(tonumber($job.runDuration$),2),"duration")</eval>
+          </progress>
+          <query>index=_internal sourcetype=scheduler source=*scheduler.log (status=success OR status=completed) alert_actions!=outputtelemetry app=$App$
+| stats max(run_time) as max_runtime_sec by savedsearch_name app
+| append [
+| rest splunk_server=local "/servicesNS/-/-/saved/searches/" 
+| search is_scheduled=1 disabled=0  eai:acl.app=$App$
+    | fields title, cron_schedule
+    | rename title as savedsearch_name 
+    | eval pieces=split(cron_schedule, " ") 
+    | eval c_min=mvindex(pieces, 0), c_h=mvindex(pieces, 1), c_d=mvindex(pieces, 2), c_mday=mvindex(pieces, 3), c_wday=mvindex(pieces, 4) 
+    | eval c_min_div=if(match(c_min, "/"), replace(c_min, "^.*/(\d+)$", "\1"), null()) 
+    | eval c_mins=if(match(c_min, ","), split(c_min, ","), null()) 
+    | eval c_min_div=if(isnotnull(c_mins), abs(tonumber(mvindex(c_mins, 1)) - tonumber(mvindex(c_mins, 0))), c_min_div) 
+    | eval c_hs=if(match(c_h, ","), split(c_h, ","), null()) 
+    | eval c_h_div=case(match(c_h, "/"), replace(c_h, "^.*/(\d+)$", "\1"), isnotnull(c_hs), abs(tonumber(mvindex(c_hs, 1)) - tonumber(mvindex(c_hs, 0))), 1=1, null()) 
+    | eval c_wdays=if(match(c_wday, ","), split(c_wday, ","), null()) 
+    | eval c_wday_div=case(match(c_wday, "/"), replace(c_wday, "^.*/(\d+)$", "\1"), isnotnull(c_wdays), abs(tonumber(mvindex(c_wdays, 1)) - tonumber(mvindex(c_wdays, 0))), 1=1, null()) 
+    | eval i_m=case(c_d &lt; 29, 86400 * 28, c_d = 31, 86400 * 31, 1=1, null()) 
+    | eval i_h=case(isnotnull(c_h_div), c_h_div * 3600, c_h = "*", null(), match(c_h, "^\d+$"), 86400) 
+    | eval i_min=case(isnotnull(c_min_div), c_min_div * 60, c_min = "*", 60, match(c_min, "^\d+$"), 3600) 
+    | eval i_wk=case(isnotnull(c_wday_div), c_wday_div * 86400, c_wday = "*", null(), match(c_wday, "^\d+$"), 604800) 
+    | eval cron_minimum_freq_sec=case(isnotnull(i_m), i_m, isnotnull(i_wk) AND isnotnull(c_min_div), i_min, isnotnull(i_wk) AND isnull(c_min_div), i_wk, isnotnull(i_h), i_h, 1=1, min(i_min)) 
+    | fields - c_d c_h c_hs c_h_div c_mday c_min c_min_div c_mins c_wday c_wdays c_wday_div pieces i_m i_min i_h i_wk 
+    | fields savedsearch_name cron_minimum_freq_sec cron_schedule]
+| stats values(*) as * by savedsearch_name
+| eval within_percent = round(max_runtime_sec/cron_minimum_freq_sec, 2)*100
+| eval Problem = if(max_runtime_sec &gt; cron_minimum_freq_sec, "max runtime exceeds frequency", if(within_percent&gt;80, "max runtime within 20% of frequeency", NULL))
+| where isnotnull(Problem)
+| sort - within_percent
+| rename savedsearch_name AS "Saved Search Name", app AS "App", cron_schedule AS "Cron Schedule" cron_minimum_freq_sec AS "Minimum Frequency (Seconds)" max_runtime_sec AS "Max Runtime (Seconds)" within_percent AS "Runtime/Frequency as %"
+| table "Saved Search Name" "App" "Cron Schedule"  "Minimum Frequency (Seconds)" "Max Runtime (Seconds)" "Problem" "Runtime/Frequency as %"</query>
+          <earliest>$freq_v_runtime_time.earliest$</earliest>
+          <latest>$freq_v_runtime_time.latest$</latest>
+        </search>
+        <option name="drilldown">none</option>
+        <option name="refresh.display">progressbar</option>
+      </table>
+      <html>
+          <h3>Panel Execution  Duration</h3>
+          <div class="custom-result-value">$lispyfreq_v_runtime$</div>
+      </html>
+    </panel>
+  </row>
+  <row>
+    <panel>
+      <html>
   <h3>Use The Fields, Luke</h3>
   <p/>
   Description: This view identifies which users avail themselves of the 4 fields every event has (index, source, sourcetype, host) in their searches, and if they use them with wildcards. Users who use less than 3 of these in their searches could use some pointers to writing better, more specific searches. Ideally every search will have an index=, source=, sourcetype= and host= defined before the first |.
   <p/>
   Actions to take: Review the values before the first | to include as many specific search terms as possible.  Assistance can be found on <a href="http://docs.splunk.com/Documentation/Splunk/latest/Search/Quicktipsforoptimization">http://docs.splunk.com/Documentation/Splunk/latest/Search/Quicktipsforoptimization</a>.
   <p/>
-  Time frame: Trending over the past 60 minutes.
 </html>
     </panel>
   </row>
   <row>
     <panel>
       <title>Use The Fields, Luke</title>
+      <input type="time" token="field_usage_time" searchWhenChanged="true">
+        <label></label>
+        <default>
+          <earliest>-24h@h</earliest>
+          <latest>now</latest>
+        </default>
+      </input>
       <table>
         <search id="use_the_fields_luke">
-          <query>user=* index=_audit action=search sourcetype=audittrail search_id=* user!="splunk-system-user" info=granted 
-| eval search=replace(search,"(search\s)(.*)","\2") 
-| eval savedsearch_name=replace(savedsearch_name,"(search\d+)","dashboard") 
-| eval savedsearch_name=if(savedsearch_name="","adhoc",savedsearch_name) 
-| stats count by user, savedsearch_name, search | rex field=search "host=(?&lt;host&gt;\S+)" 
-| rex field=search "sourcetype=(?&lt;sourcetype&gt;\S+)" 
-| rex field=search "source=(?&lt;source&gt;\S+)" 
-| rex field=search "index=(?&lt;index&gt;[^\s\=]+)" 
-| eval index=trim(index,"\""), host=trim(host,"\"\\'"), sourcetype=trim(sourcetype,"\"") ,source=trim(source,"\"") 
-| stats values(index) as searched_indexes, values(sourcetype) as searched_sourcetypes, values(source) as searched_sources, values(host) as searched_hosts by user
-</query>
-          <earliest>-60m@m</earliest>
-          <latest>now</latest>
-          <sampleRatio>1</sampleRatio>
           <progress>
             <eval token="fieldsluke_duration">tostring(round(tonumber($job.runDuration$),2),"duration")</eval>
           </progress>
+          <query>index=_audit sourcetype=audittrail action=search search_id!="rsa_*" user!=splunk-system-user info IN(completed, granted) app=$App$
+| eval search=replace(search,"(search\s)(.*)","\2") 
+| eval savedsearch_name=replace(savedsearch_name,"(search\d+)","dashboard") 
+| eval savedsearch_name=if(savedsearch_name="","adhoc",savedsearch_name)
+| stats count by user, savedsearch_name, search app
+| rex field=search "host=(?&lt;host&gt;\S+)"
+| rex field=search "sourcetype=(?&lt;sourcetype&gt;\S+)"  
+| rex field=search "source=(?&lt;source&gt;\S+)"  
+| rex field=search "index=(?&lt;index&gt;[^\s\=]+)"
+| eval index=trim(index,"\""), host=trim(host,"\"\\'"), sourcetype=trim(sourcetype,"\"") ,source=trim(source,"\"")
+| stats values(index) as searched_indexes, values(sourcetype) as searched_sourcetypes, values(source) as searched_sources, values(host) as searched_hosts by user app</query>
+          <earliest>$field_usage_time.earliest$</earliest>
+          <latest>$field_usage_time.latest$</latest>
+          <sampleRatio>1</sampleRatio>
         </search>
         <option name="count">10</option>
         <option name="dataOverlayMode">none</option>
         <option name="drilldown">cell</option>
         <option name="percentagesRow">false</option>
+        <option name="refresh.display">progressbar</option>
         <option name="rowNumbers">false</option>
         <option name="totalsRow">false</option>
         <option name="wrap">true</option>
@@ -260,34 +370,40 @@
   </row>
   <row>
     <panel>
+      <input type="time" token="search_span_time" searchWhenChanged="true">
+        <label></label>
+        <default>
+          <earliest>-24h@h</earliest>
+          <latest>now</latest>
+        </default>
+      </input>
       <html>
-  <h3>Search Span</h3>
+  <h3>Search Duration</h3>
   <p/>
-  Description: The span panels help visualize where search load is coming from. Left panel is a explicit breakdown of number of searches and span between beginning and end. Right panel is similar, but buckets the searches into groups.
+  Description: The duration panels help visualize where search load is coming from. Left panel is a explicit breakdown of number of searches and duration between beginning and end. Right panel is similar, but buckets the searches into groups.
   <p/>
   Actions to take: Review how often searches are scheduled to run - do all the searches running every 1, 5, 10 or 15 minutes need to run as frequently? Consider enabling the scheduler window for searches so that Splunk can adjust their execution timing to spread the load out. Assistance can be found on <a href="http://docs.splunk.com/Documentation/Splunk/latest/Report/Schedulereports">http://docs.splunk.com/Documentation/Splunk/latest/Report/Schedulereports</a>. For frequently run searches, ensure that they are as fast as possible with each search being as specific as possible before the first pipe, including index sourcetype host or other values whenever possible.
   <p/>
-  Time frame: Trending over the past 60 minutes.
 </html>
     </panel>
   </row>
   <row>
     <panel>
-      <title>Span #1</title>
+      <title>Search Spans #1</title>
       <table>
-        <search id="exact_span">
-          <query>index=_audit info=completed sourcetype=audittrail source=audittrail action=search
+        <search id="exact_duration">
+          <progress>
+            <eval token="exactdur_duration">tostring(round(tonumber($job.runDuration$),2),"duration")</eval>
+          </progress>
+          <query>index=_audit app=$App$ info=completed sourcetype=audittrail source=audittrail action=search
 | eval search_span=round(search_lt-search_et)
 | eval search_span=tostring(abs(search_span), "duration")
 | top limit=12 search_span
 | rename count AS "Count", percent AS "Percent", search_span AS "Search Span (clickable)"
 | table "Search Span (clickable)", "Count", "Percent"</query>
-          <earliest>-60m@m</earliest>
-          <latest>now</latest>
+          <earliest>$search_span_time.earliest$</earliest>
+          <latest>$search_span_time.latest$</latest>
           <sampleRatio>1</sampleRatio>
-          <progress>
-            <eval token="exactdur_duration">tostring(round(tonumber($job.runDuration$),2),"duration")</eval>
-          </progress>
         </search>
         <option name="count">20</option>
         <option name="dataOverlayMode">none</option>
@@ -313,14 +429,17 @@
       </html>
     </panel>
     <panel>
-      <title>Span #2</title>
+      <title>Search Spans #2</title>
       <table>
-        <search id="bucketed_span">
-          <query>index=_audit sourcetype=audittrail source=audittrail TERM(action=search) ( TERM(info=completed)  OR ( TERM(info=granted) apiStartTime "search='search")) NOT "search_id='rsa_*"
+        <search id="bucketed_duration">
+          <progress>
+            <eval token="bucketeddur_duration">tostring(round(tonumber($job.runDuration$),2),"duration")</eval>
+          </progress>
+          <query>index=_audit sourcetype=audittrail source=audittrail action=search info IN(completed, granted) search="'search*" NOT("search_id='rsa_*") app=$App$
 | eval u=case( searchmatch("user=splunk-system-user OR user=nobody OR search_id=*scheduler_*"), "Scheduler", searchmatch(("search_id='1*")), "AdHocUser", 1=1, "AdHocSaved")
 | eval search_id=md5(search_id), search_et=if(search_et="N/A", 0, search_et), search_lt=if(search_lt="N/A", exec_time, search_lt), et_diff=case(exec_time&gt;search_et, (exec_time-search_et)/60, 1=1, (search_lt-search_et)/60), searchStrLen=len(search)
 | stats partitions=10 sum(searchStrLen) AS searchStrLen, count, first(et_diff) AS et_diff, first(u) as u, values(search) AS search BY search_id
-| search searchStrLen&gt;0 et_diff=* count&gt;1
+| search searchStrLen&gt;0 et_diff=* 
 | eval Et_range=case(et_diff&lt;=0, "WTF", et_diff&lt;2, "0_1m", et_diff&lt;6, "1_5m", et_diff&lt;11, "2_10m", et_diff&lt;16, "3_15m", et_diff&lt;=65, "4_60m", et_diff&lt;=4*60+10, "5_4h", et_diff&lt;=24*60+10, "6_24h", et_diff&lt;=7*24*60+10, "7_7d", et_diff&lt;=30*24*60+10, "8_30d", et_diff&lt;=90*24*60+10, "9_90d", 1=1, "10_&gt;90d")
 | chart count by Et_range, u
 | eval Total=AdHocUser + AdHocSaved + Scheduler
@@ -333,14 +452,11 @@
 | accum TotalPerc AS TotalPercCumulative
 | eval TotalPercCumulative=if(TotalPercCumulative&lt;101, round(TotalPercCumulative, 1), "")
 | rename Et_range AS "Search Span"</query>
-          <earliest>-60m@m</earliest>
-          <latest>now</latest>
+          <earliest>$search_span_time.earliest$</earliest>
+          <latest>$search_span_time.latest$</latest>
           <sampleRatio>1</sampleRatio>
-          <progress>
-            <eval token="bucketeddur_duration">tostring(round(tonumber($job.runDuration$),2),"duration")</eval>
-          </progress>
         </search>
-        <option name="count">100</option>
+        <option name="count">20</option>
         <option name="dataOverlayMode">none</option>
         <option name="drilldown">cell</option>
         <option name="percentagesRow">false</option>
@@ -363,7 +479,6 @@
   <p/>
   Actions to take: Review how often searches are scheduled to run and which minutes of the clock to run on - do all the searches running frequently need to run at the default 5, 10, 15, et al minute boundaries? Spread searches out to lesser utilized minutes each hour. Assistance can be found on <a href="http://docs.splunk.com/Documentation/Splunk/latest/Alert/CronExpressions">http://docs.splunk.com/Documentation/Splunk/latest/Alert/CronExpressions</a>.
   <p/>
-  Time frame: Trending over the past 60 minutes by default.
 </html>
     </panel>
   </row>
@@ -386,17 +501,17 @@
       </input>
       <chart>
         <search id="system_wide_scheduling">
-          <query>| rest /servicesNS/-/-/saved/searches splunk_server=local search="is_scheduled=1" search="disabled=0" earliest_time=$time_range_all.earliest$ latest_time=$time_range_all.latest$ timeout=0
-          | table title cron_schedule scheduled_times 
+          <progress>
+            <eval token="syswidesched_duration">tostring(round(tonumber($job.runDuration$),2),"duration")</eval>
+          </progress>
+          <query>| rest /servicesNS/-/-/saved/searches splunk_server=local search="is_scheduled=1" search="disabled=0" earliest_time=$time_range_all.earliest$ latest_time=$time_range_all.latest$ search="eai:acl.app=$App$" timeout=0
+          | table title cron_schedule scheduled_times eai:acl.app
           | mvexpand scheduled_times 
-          | rename scheduled_times as _time 
+          | rename scheduled_times as _time eai:acl.app AS App
           | timechart span=$timespan_all$ count as "Searches Scheduled"</query>
           <earliest>$time_range_all.earliest$</earliest>
           <latest>$time_range_all.latest$</latest>
           <sampleRatio>1</sampleRatio>
-          <progress>
-            <eval token="syswidesched_duration">tostring(round(tonumber($job.runDuration$),2),"duration")</eval>
-          </progress>
         </search>
         <option name="charting.axisLabelsX.majorLabelStyle.overflowMode">ellipsisNone</option>
         <option name="charting.axisLabelsX.majorLabelStyle.rotation">0</option>
@@ -422,6 +537,7 @@
         <option name="charting.legend.labelStyle.overflowMode">ellipsisMiddle</option>
         <option name="charting.legend.placement">right</option>
         <option name="height">400</option>
+        <option name="refresh.display">progressbar</option>
       </chart>
       <html>
           <h3>Panel Execution Duration</h3>
@@ -438,7 +554,6 @@
   <p/>
   Actions to take: Review how often searches are scheduled to run and which minutes of the clock to run on - do all the searches running frequently need to run at the default 5, 10, 15, et al minute boundaries? Spread searches out to lesser utilized minutes each hour. Assistance can be found on <a href="http://docs.splunk.com/Documentation/Splunk/latest/Alert/CronExpressions">http://docs.splunk.com/Documentation/Splunk/latest/Alert/CronExpressions</a>.
   <p/>
-  Time frame: Trending over the past 60 minutes by default.
 </html>
     </panel>
   </row>
@@ -461,7 +576,10 @@
       </input>
       <chart>
         <search id="per_app_scheduling">
-          <query>| rest /servicesNS/-/-/saved/searches splunk_server=local search="is_scheduled=1" search="disabled=0" earliest_time=$time_range_app.earliest$ latest_time=$time_range_app.latest$ timeout=0
+          <progress>
+            <eval token="appwidesched_duration">tostring(round(tonumber($job.runDuration$),2),"duration")</eval>
+          </progress>
+          <query>| rest /servicesNS/-/-/saved/searches splunk_server=local search="is_scheduled=1" search="disabled=0" earliest_time=$time_range_app.earliest$ latest_time=$time_range_app.latest$ search="eai:acl.app=$App$" timeout=0
 | table title cron_schedule scheduled_times eai:acl.app 
 | mvexpand scheduled_times 
 | rename scheduled_times as _time 
@@ -478,9 +596,6 @@
           <earliest>$time_range_app.earliest$</earliest>
           <latest>$time_range_app.latest$</latest>
           <sampleRatio>1</sampleRatio>
-          <progress>
-            <eval token="appwidesched_duration">tostring(round(tonumber($job.runDuration$),2),"duration")</eval>
-          </progress>
         </search>
         <option name="charting.axisLabelsX.majorLabelStyle.overflowMode">ellipsisNone</option>
         <option name="charting.axisLabelsX.majorLabelStyle.rotation">0</option>
@@ -510,6 +625,7 @@
         <option name="charting.legend.mode">standard</option>
         <option name="charting.legend.placement">none</option>
         <option name="charting.lineWidth">2</option>
+        <option name="refresh.display">progressbar</option>
         <option name="trellis.enabled">1</option>
         <option name="trellis.scales.shared">0</option>
         <option name="trellis.size">small</option>
@@ -529,7 +645,6 @@
   <p/>
   Actions to take: Review how often searches are scheduled to run and which minutes of the clock to run on - do all the searches running frequently need to run at the default 5, 10, 15, et al minute boundaries? Spread searches out to lesser utilized minutes each hour. Assistance can be found on <a href="http://docs.splunk.com/Documentation/Splunk/latest/Alert/CronExpressions">http://docs.splunk.com/Documentation/Splunk/latest/Alert/CronExpressions</a>.
   <p/>
-  Time frame: Trending over the past 60 minutes by default.
 </html>
     </panel>
   </row>
@@ -552,7 +667,10 @@
       </input>
       <chart>
         <search id="per_user_scheduling">
-          <query>| rest /servicesNS/-/-/saved/searches splunk_server=local search="is_scheduled=1" search="disabled=0" earliest_time=$time_range_user.earliest$ latest_time=$time_range_user.latest$ timeout=0
+          <progress>
+            <eval token="perusersched_duration">tostring(round(tonumber($job.runDuration$),2),"duration")</eval>
+          </progress>
+          <query>| rest /servicesNS/-/-/saved/searches splunk_server=local search="is_scheduled=1" search="disabled=0" earliest_time=$time_range_user.earliest$  latest_time=$time_range_user.latest$ search="eai:acl.app=$App$" timeout=0
 | table title cron_schedule scheduled_times eai:acl.owner 
 | mvexpand scheduled_times 
 | rename scheduled_times as _time 
@@ -569,9 +687,6 @@
           <earliest>$time_range_user.earliest$</earliest>
           <latest>$time_range_user.latest$</latest>
           <sampleRatio>1</sampleRatio>
-          <progress>
-            <eval token="perusersched_duration">tostring(round(tonumber($job.runDuration$),2),"duration")</eval>
-          </progress>
         </search>
         <option name="charting.axisLabelsX.majorLabelStyle.overflowMode">ellipsisNone</option>
         <option name="charting.axisLabelsX.majorLabelStyle.rotation">0</option>
@@ -601,6 +716,7 @@
         <option name="charting.legend.mode">standard</option>
         <option name="charting.legend.placement">none</option>
         <option name="charting.lineWidth">2</option>
+        <option name="refresh.display">progressbar</option>
         <option name="trellis.enabled">1</option>
         <option name="trellis.scales.shared">0</option>
         <option name="trellis.size">medium</option>
@@ -618,11 +734,10 @@
   <p/>
   Description: Buckets searches into common frequency of scheduling, every 1, 5, 10, 15, 30 or 60 minutes and all remainders. This assists with identifying causes of skipped searches when the SH hits maximum historical search capacity.
   <p/>
-  Actions to take: Review how often searches are scheduled to run - do all the searches running every 1, 5, 10 or 15 minutes need to run as frequently? Consider enabling the scheduler window for searches so that Splunk can adjust their execution timing to spread the load out. For multiple searches that have to run every 5 minutes, spread them out from */5 (or "every 5 minutes") to 1-59/5, 2-59/5, 3-59/5, 4-59/5, to take advantage of every available minute per hour. Do the same for longer intervals, skipping multiples of 5 (i.e., for */10 use 1, 2, 3, 4, 6, 7, 8, 9).  Assistance can be found on <a href="http://docs.splunk.com/Documentation/Splunk/latest/Alert/CronExpressions">http://docs.splunk.com/Documentation/Splunk/latest/Alert/CronExpressions</a>.
+  Actions to take: Review how often searches are scheduled to run - do all the searches running every 1, 5, 10 or 15 minutes need to run as frequently? Consider enabling the scheduler window for searches so that Splunk can adjust their execution timing to spread the load out. For multiple searches that have to run every 5 minutes, spread them out from */5 (or "every 5 minutes") to 0-59/5, 1-59/5, 2-59/5, 3-59/5, 4-59/5, to take advantage of every available minute per hour. Assistance can be found on <a href="http://docs.splunk.com/Documentation/Splunk/latest/Alert/CronExpressions">http://docs.splunk.com/Documentation/Splunk/latest/Alert/CronExpressions</a>.
   <p/>
   Additionally, enabling the search names helps with identifying groups of searches that may be ripe for consolidation. Look for searches named very close to each other that look for similar types of things, like unique error messages, status codes, et al that exist within the same application context in the Splunk environment.
   <p/>
-  Time frame: Trending over the past 24 hours.
 </html>
     </panel>
   </row>
@@ -636,23 +751,24 @@
         <default>Search_Count Cron</default>
       </input>
       <table>
+        <title>No time picker as based on | rest search</title>
         <search id="frequency_of_scheduled">
-          <query>| rest splunk_server=local "/servicesNS/-/-/saved/searches/" search="is_scheduled=1" search="disabled=0"
+          <progress>
+            <eval token="freqofsched_duration">tostring(round(tonumber($job.runDuration$),2),"duration")</eval>
+          </progress>
+          <query>| rest splunk_server=local "/servicesNS/-/-/saved/searches/" search="is_scheduled=1" search="disabled=0" search="eai:acl.app=$App$"
 | fields title, eai:acl.app, eai:acl.owner, cron_schedule, dispatch.earliest_time, dispatch.latest_time, schedule_window, actions
 | rename title as "Report_Name", cron_schedule as "Cron_Schedule"
 | eval Frequency=if(like(Cron_Schedule,"*/1 %"),"1min",if(like(Cron_Schedule,"* * * * *"),"1min",if(like(Cron_Schedule,"%/5 %"),"5min", if(like(Cron_Schedule,"%/10 %"),"10min",if(like(Cron_Schedule,"*/15 %"),"15min",if(like(Cron_Schedule,"0 %"),"Top of the Hour","other"))))))
 | stats count(Report_Name) AS Search_Count values(Report_Name) AS Search_Names values(Cron_Schedule) AS Cron by Frequency
 | addcoltotals labelfield=Frequency label="Total Searches Scheduled" 
 | sort - Search_Count
-| table Frequency $include_search_name$ </query>
+| table Frequency $include_search_name$</query>
           <earliest>-24h@h</earliest>
           <latest>now</latest>
           <sampleRatio>1</sampleRatio>
-          <progress>
-            <eval token="freqofsched_duration">tostring(round(tonumber($job.runDuration$),2),"duration")</eval>
-          </progress>
         </search>
-        <option name="count">100</option>
+        <option name="count">10</option>
         <option name="dataOverlayMode">none</option>
         <option name="drilldown">cell</option>
         <option name="percentagesRow">false</option>
@@ -671,26 +787,30 @@
       <html>
         <h3>Heavy Weight Dashboards</h3>
         <p/>
-          Description: Dashboards which trigger one or more limits associated with the role of the user loading them. These limits can be disk quota, per-role search concurrency, or max search concurrency per search head. Hitting limits results in poor user experience, and can range from the dashboard panels never loading (disk quota exceeded) to long waits for queued searches to execute. The type of limit hit will determine what steps can be taken to alleviate the poor user experience.
+          Description: Dashboards which trigger one or more limits associated with the role of the user loading them. These limits can be disk quota, per role search concurrency, or search head wide max search concurrency. Hitting limits results in poor user experience, and can range from the dashboard panels never loading (disk quota exceeded) to long waits for queued searches to execute. The type of limit hit will determine what steps can be taken to alleviate the poor user experience.
         <p/>
-          Problem descriptions and actions to take:
-          <ul>
-            <li>Disk quota: Users in the same role are collectively using too much disk space. Raising the disk quota may be an easy way to improve the user experience for that dashboard.</li>
-            <li>Per-role search concurrency: Users in the same role are trying to run too many searches at once. Users in different roles with different thresholds may have trouble on the same dashboard. Consider raising the search concurrency rate for one or more roles that frequently use the dashboard.</li>
-            <li>System-wide concurrency: All users, combined, are trying to run too many searches at once. A more holistic look at the number of searches being executed from dashboards, ad-hoc searches, and scheduled searches is in order, which is beyond the scope of this panel. Engage your account team to determine the best resource to help.</li>
-          </ul>
+          Actions to take: There are several options for quick fixes. For the limit type being hit for a specific dashboard is disk quota and users from the same role are the ones that primary hit this limit, then raising the disk quota may be an easy way to improve the user experience for that dashboard. For dashboards that cause per role search concurrency limits to be hit (users in different roles with different thresholds may get hit on the same dashboard), consider raising the search concurrency rate for one or more roles that frequently use the dashboard. If the system wide max concurrency setting is being hit, a more holistic look at the number of searches being executed from dashboards, ad-hoc searches and scheduled searches is in order, which is beyond the scope of this panel.
         <p/>
-          Longer term actions to take for all types of limits being hit are to investigate improving individual dashboards. Improvement options include: using <a href="https://docs.splunk.com/Documentation/Splunk/latest/Viz/Savedsearches#Post-process_searches_2">base searches</a> for similar results set with post-process searches keying off one or more base searches, using <a href="https://docs.splunk.com/Documentation/Splunk/latest/Knowledge/Acceleratedatamodels">Data Model Accelerations</a> or <a href="https://docs.splunk.com/Documentation/Splunk/latest/Report/Acceleratereports">report acceleration</a>, using <a href="https://docs.splunk.com/Documentation/Splunk/latest/Knowledge/Usesummaryindexing">summary indexing</a>, or referencing the results from a <a href="https://docs.splunk.com/Documentation/Splunk/latest/Search/Schedulingsearches">scheduling searched</a>. These techniques can be combined to vastly improve performance and efficiency of heavily used dashboards.
+          Longer term actions to take for all types of limits being hit are to investigate improving individual dashboards. Improvement options include: using <a href="https://docs.splunk.com/Documentation/Splunk/7.2.5/Viz/Savedsearches#Post-process_searches_2">base searches</a> for similar results set with post-process searches keying off one or more base searches, using <a href="https://docs.splunk.com/Documentation/Splunk/latest/Knowledge/Acceleratedatamodels">Data Model Accelerations</a> or <a href="https://docs.splunk.com/Documentation/Splunk/latest/Report/Acceleratereports">report acceleration</a>, using <a href="https://docs.splunk.com/Documentation/Splunk/latest/Knowledge/Usesummaryindexing">summary indexing</a>, or referencing the results from a <a href="hhttps://docs.splunk.com/Documentation/Splunk/7.2.5/Search/Schedulingsearches">scheduling searched</a>. These techniques can be combined to vastly improve performance and efficiency of heavily used dashboards.
         <p/>
-        Time frame: Trending over the past 24 hours.
       </html>
     </panel>
   </row>
   <row>
     <panel>
       <title>Heavy Weight Dashboards</title>
+      <input type="time" token="heavy_dashboard_time">
+        <label></label>
+        <default>
+          <earliest>-24h@h</earliest>
+          <latest>now</latest>
+        </default>
+      </input>
       <table>
         <search id="heavy_weight_dashboards">
+          <progress>
+            <eval token="heavyweight_duration">tostring(round(tonumber($job.runDuration$),2),"duration")</eval>
+          </progress>
           <query>index=_internal sourcetype=splunkd reason="The maximum*" provenance=UI:Dashboard:* source="*splunkd.log" 
 | rex field=provenance mode=sed "s/UI:Dashboard://g" 
 | rex field=id "(?&lt;user&gt;[^_]+)"
@@ -699,13 +819,11 @@
     [search index=_internal sourcetype=splunkd reason="The maximum*" provenance=UI:Dashboard:* source="*splunkd.log" 
     | rex field=provenance mode=sed "s/UI:Dashboard://g" 
     | rex field=id "(?&lt;user&gt;[^_]+)"
-    | chart count over provenance by reason]</query>
-          <earliest>-24h</earliest>
-          <latest>now</latest>
+    | chart count over provenance by reason]
+| fields provenance "Unique Users" * "Usage Trend"</query>
+          <earliest>$heavy_dashboard_time.earliest$</earliest>
+          <latest>$heavy_dashboard_time.latest$</latest>
           <sampleRatio>1</sampleRatio>
-          <progress>
-            <eval token="heavyweight_duration">tostring(round(tonumber($job.runDuration$),2),"duration")</eval>
-          </progress>
         </search>
         <option name="count">10</option>
         <option name="dataOverlayMode">none</option>
@@ -748,8 +866,13 @@
     <panel>
       <title>Automatically Refreshing Dashboards</title>
       <table>
+        <title>No time picker as based on | rest search</title>
         <search id="refresh_dashboards">
+          <progress>
+            <eval token="dashboard_refreshs">tostring(round(tonumber($job.runDuration$),2),"duration")</eval>
+          </progress>
           <query>| rest splunk_server=local servicesNS/-/-/data/ui/views timeout=0 
+| search eai:appName=$App$
 | regex eai:data="(&lt;earliest&gt;rt-\d+[^\&lt;]+|&lt;refresh&gt;\d+|refresh=\"[^\"]+)" 
 | rex field="eai:data" "&lt;refresh&gt;(?&lt;refresh_time&gt;\d+[^\&lt;]+)&lt;\/refresh&gt;" max_match=30 
 | rex field="eai:data" "refresh=\"(?&lt;refresh_time&gt;[^\"]+)\"" max_match=30 
@@ -766,11 +889,8 @@
           <earliest>-30m@m</earliest>
           <latest>now</latest>
           <sampleRatio>1</sampleRatio>
-          <progress>
-            <eval token="dashboard_refreshs">tostring(round(tonumber($job.runDuration$),2),"duration")</eval>
-          </progress>
         </search>
-        <option name="count">20</option>
+        <option name="count">10</option>
         <option name="dataOverlayMode">none</option>
         <option name="drilldown">none</option>
         <option name="percentagesRow">false</option>
@@ -788,7 +908,7 @@
     <panel>
       <html>
         <h3>Acknowledgements</h3>
-      <p>This view has been made a whole lot better as I stood on the shoulders of giants who assisted with great feedback and improvements. Thank you Anand Ladda, Joe Gedeon, Martin Mueller, Gream Park, Dawn Taylor, Sanford Owings, Rich Galloway, Michael Uschmann, Amir Khamis, Gareth Anderson, Darrel Huntington, Estela Baca, and Nate Plamondon.</p> </html>
+      <p>This view has been made a whole lot better as I stood on the shoulders of giants who assisted with great feedback and improvements. Thank you Anand Ladda, Joe Gedeon, Martin Mueller, Gream Park, Dawn Taylor, Sanford Owings, Rich Galloway, Michael Uschmann, Amir Khamis, Gareth Anderson and Darrel Huntington.</p> </html>
     </panel>
   </row>
 </form>


### PR DESCRIPTION
-Added the ability to filter results by App
-Removing hard-coded time values and adding time pickers -Clarifying that original usage of the term "duration" actually meant search span in order to distinguish those panels from a new panel related to comparing search frequency to run-time. 
- Adjusted search syntax for some searches that did not function in our environment b/c we aren't getting fields like `info=granted` so added `OR info=completed` and similar.  
- Adjusted formatting of panels to account for extremely large results